### PR TITLE
feat: move from tui to ratatui 0.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ Various crates related to handling terminal user interfaces.
 
 # Maintenance Notes
 
-## Upgrading TUI
+## Upgrading Ratatui
 
-1. upgrade `tui` in `tui-react`, increment mionr in `tui-react`  and `cargo publish`.
-1. uprgade `tui` and `tui-react` in `crosstermion` and `cargo release`.
-
+1. upgrade `ratatui` in `tui-react`, increment mionr in `tui-react`  and `cargo publish`.
+1. upgrade `ratatui` and `tui-react` in `crosstermion` and `cargo release`.
 
 ## Upgrading Crossterm
 
-You can't - it comes as tui backend and thus we need tui to upgrade to the latest crossterm first.
+You can't - it comes as ratatui backend and thus we need ratatui to upgrade to the latest crossterm first.

--- a/crosstermion/Cargo.toml
+++ b/crosstermion/Cargo.toml
@@ -17,23 +17,23 @@ color = ["ansi_term"]
 input-async = ["futures-channel", "async-channel", "futures-lite", "futures-core" ]
 input-async-crossterm = ["crossterm/event-stream", "input-async"]
 
-tui-termion = ["tui", "tui-termion-backend", "termion"]
-tui-react-termion = ["tui-react", "tui", "tui-termion-backend", "termion"]
+tui-termion = ["ratatui", "tui-termion-backend", "termion"]
+tui-react-termion = ["tui-react", "ratatui", "tui-termion-backend", "termion"]
 
-tui-crossterm = ["tui", "tui-crossterm-backend", "crossterm"]
-tui-react-crossterm = ["tui-react", "tui", "tui-crossterm-backend", "crossterm"]
+tui-crossterm = ["ratatui", "tui-crossterm-backend", "crossterm"]
+tui-react-crossterm = ["tui-react", "ratatui", "tui-crossterm-backend", "crossterm"]
 
-tui-termion-backend = ["tui/termion"] # redirect is needed to allow us to #[cfg(feature = "…")] against it. You can't see features of crates
-tui-crossterm-backend = ["tui/crossterm"]
+tui-termion-backend = ["ratatui/termion"] # redirect is needed to allow us to #[cfg(feature = "…")] against it. You can't see features of crates
+tui-crossterm-backend = ["ratatui/crossterm"]
 
 
 [dependencies]
-crossterm = { version = "0.25.0", optional = true, default-features = false }
-termion = { version = "1.5.5", optional = true, default-features = false }
+crossterm = { version = "0.26.1", optional = true, default-features = false }
+termion = { version = "2.0.1", optional = true, default-features = false }
 futures-channel = { version = "0.3.5", optional = true, default-features = false, features = ["std", "sink"] }
 futures-core = { version = "0.3.5", optional = true, default-features = false }
 futures-lite = { version = "1.4.0", optional = true }
-tui = { version = "0.19.0", optional = true, default-features = false }
+ratatui = { version = "0.20.1", optional = true, default-features = false }
 tui-react = { version = "^0.19.0", optional = true, default-features = false, path = "../tui-react" }
 ansi_term = { version = "0.12.1", optional = true, default-features = false }
 async-channel = { version = "1.1.1", optional = true }

--- a/crosstermion/Makefile
+++ b/crosstermion/Makefile
@@ -10,7 +10,7 @@ check: ## build features in commmon combination to be sure it all stays together
 	$(MAKE) check-windows
 	cargo check --features termion
 	cargo check --features termion,input-async
-	cargo check --features termion,tui
+	cargo check --features termion,ratatui
 	cargo check --features tui-react-termion
 	cargo check --features tui-react-termion,input-async
 	cargo check --features tui-termion
@@ -21,7 +21,7 @@ check: ## build features in commmon combination to be sure it all stays together
 check-windows: ## build features in commmon combination to be sure it all stays together, crossterm only
 	cargo check --features crossterm
 	cargo check --features crossterm,input-async
-	cargo check --features crossterm,tui
+	cargo check --features crossterm,ratatui
 	cargo check --features tui-react-crossterm
 	cargo check --features tui-react-crossterm,input-async
 	cargo check --features tui-crossterm

--- a/crosstermion/src/lib.rs
+++ b/crosstermion/src/lib.rs
@@ -16,9 +16,9 @@ pub mod color;
 pub use ansi_term;
 #[cfg(feature = "crossterm")]
 pub use crossterm;
+#[cfg(feature = "ratatui")]
+pub use ratatui;
 #[cfg(feature = "termion")]
 pub use termion;
-#[cfg(feature = "tui")]
-pub use tui;
 #[cfg(feature = "tui-react")]
 pub use tui_react;

--- a/crosstermion/src/terminal.rs
+++ b/crosstermion/src/terminal.rs
@@ -46,7 +46,7 @@ mod _impl {
 
     #[cfg(all(feature = "tui-crossterm-backend", not(feature = "tui-react")))]
     pub mod tui {
-        use tui::backend::CrosstermBackend;
+        use ratatui::backend::CrosstermBackend;
 
         pub fn new_terminal<W: std::io::Write>(
             write: W,
@@ -58,7 +58,7 @@ mod _impl {
 
     #[cfg(all(feature = "tui-crossterm-backend", feature = "tui-react"))]
     pub mod tui {
-        use tui::backend::CrosstermBackend;
+        use ratatui::backend::CrosstermBackend;
 
         pub fn new_terminal<W: std::io::Write>(
             write: W,
@@ -72,8 +72,8 @@ mod _impl {
 #[cfg(feature = "termion")]
 mod _impl {
     use std::io;
+    use termion::screen::IntoAlternateScreen;
     pub use termion::terminal_size as size;
-
     pub struct AlternateRawScreen<T: io::Write> {
         inner: termion::screen::AlternateScreen<T>,
     }
@@ -83,7 +83,7 @@ mod _impl {
             use termion::raw::IntoRawMode;
             let write = write.into_raw_mode()?;
             Ok(AlternateRawScreen {
-                inner: termion::screen::AlternateScreen::from(write),
+                inner: write.into_alternate_screen()?,
             })
         }
     }
@@ -100,7 +100,7 @@ mod _impl {
 
     #[cfg(all(feature = "tui-termion-backend", not(feature = "tui-react")))]
     pub mod tui {
-        use tui::backend::TermionBackend;
+        use ratatui::backend::TermionBackend;
 
         pub fn new_terminal<W: std::io::Write>(
             write: W,
@@ -115,7 +115,7 @@ mod _impl {
     /// Requires the `tui-react` and `tui-crossterm-backend` features set.
     #[cfg(all(feature = "tui-termion-backend", feature = "tui-react"))]
     pub mod tui {
-        use tui::backend::TermionBackend;
+        use ratatui::backend::TermionBackend;
 
         /// Returns a new Terminal instance with a suitable backend.
         pub fn new_terminal<W: std::io::Write>(

--- a/tui-react/Cargo.toml
+++ b/tui-react/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tui = { version = "0.19.0", default-features = false }
+ratatui = { version = "0.20.1", default-features = false }
 log = "0.4.6"
 unicode-segmentation = "1.6.0"
 unicode-width = "0.1.7"

--- a/tui-react/README.md
+++ b/tui-react/README.md
@@ -4,7 +4,7 @@ Please note that this crate is early in development and build for the needs of *
 
 ### How it works
 
-It uses the TUI infrastructure Terminal, but alters it to not enforce implementing the `Widget` trait. 
+It uses the Ratatui infrastructure Terminal, but alters it to not enforce implementing the `Widget` trait.
 It provides only a single, optional, trait called `TopLevelComponent`, which makes it convenient to
 draw its implementors with `Terminal::render(..)`. However, since this enforces the absence of
 refernces in your state, it's probably not suitable for most.
@@ -17,11 +17,10 @@ greatly adding to flexibility.
 State that one wants within the component for instance could be the scoll location. Alternatively,
 one can configure windows by altering their public state.
 
-### What's the relation to TUI?
+### What's the relation to TUI / Ratatui?
 
-This project coudln't exist without it, and is happy to provide an alternative set of components
-for use in command-line applications.
-
+This project coudln't exist without TUI, and is happy to provide an alternative set of components
+for use in command-line applications. Ratatui is the continuation of the tui project.
 
 ### Why `tui-react`?
 

--- a/tui-react/src/lib.rs
+++ b/tui-react/src/lib.rs
@@ -6,8 +6,8 @@ mod terminal;
 pub use list::*;
 pub use terminal::*;
 
+use ratatui::{self, buffer::Buffer, layout::Rect, style::Color, style::Style};
 use std::iter::repeat;
-use tui::{self, buffer::Buffer, layout::Rect, style::Color, style::Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -117,7 +117,7 @@ pub mod util {
     }
 
     pub mod rect {
-        use tui::layout::Rect;
+        use ratatui::layout::Rect;
 
         /// A safe version of Rect::intersection that doesn't suffer from underflows
         pub fn intersect(lhs: Rect, rhs: Rect) -> Rect {

--- a/tui-react/src/list.rs
+++ b/tui-react/src/list.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     text::{Span, Spans, Text},

--- a/tui-react/src/terminal.rs
+++ b/tui-react/src/terminal.rs
@@ -2,7 +2,7 @@
 use log::error;
 use std::{borrow::Borrow, io};
 
-use tui::{backend::Backend, buffer::Buffer, layout::Rect};
+use ratatui::{backend::Backend, buffer::Buffer, layout::Rect};
 
 /// A component meant to be rendered by `Terminal::render(...)`.
 /// All other components don't have to implement this trait, and instead
@@ -136,7 +136,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tui::backend::TestBackend;
+    use ratatui::backend::TestBackend;
 
     #[derive(Default, Clone)]
     struct ComplexProps {


### PR DESCRIPTION
- bump termion to 2.0.1
- bump crossterm to 0.26.1
- use ratatui module instead of tui

Leaves the feature names as tui-* to avoid breaking dependents

I ran make tests to confirm and updated prodash and dua too (PRs to come)

[![asciicast](https://asciinema.org/a/6bzustyRZCzquhxgpsJpMEyfj.svg)](https://asciinema.org/a/6bzustyRZCzquhxgpsJpMEyfj)

[![asciicast](https://asciinema.org/a/gkbGZ3SW5yRv7NjDZVp1q5cEM.svg)](https://asciinema.org/a/gkbGZ3SW5yRv7NjDZVp1q5cEM)