### PR TITLE
switch to `ratatui` - minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Various crates related to handling terminal user interfaces.
 
 ## Upgrading TUI
 
-1. upgrade `tui` in `tui-react`, increment mionr in `tui-react`  and `cargo publish`.
+1. upgrade `tui` in `tui-react`, increment minor in `tui-react`  and `cargo publish`.
 1. uprgade `tui` and `tui-react` in `crosstermion` and `cargo release`.
 
 

--- a/crosstermion/Cargo.toml
+++ b/crosstermion/Cargo.toml
@@ -33,7 +33,7 @@ termion = { version = "1.5.5", optional = true, default-features = false }
 futures-channel = { version = "0.3.5", optional = true, default-features = false, features = ["std", "sink"] }
 futures-core = { version = "0.3.5", optional = true, default-features = false }
 futures-lite = { version = "1.4.0", optional = true }
-tui = { version = "0.19.0", optional = true, default-features = false }
+tui = { package = "ratatui", version = "0.20.1", optional = true, default-features = false }
 tui-react = { version = "^0.19.0", optional = true, default-features = false, path = "../tui-react" }
 ansi_term = { version = "0.12.1", optional = true, default-features = false }
 async-channel = { version = "1.1.1", optional = true }

--- a/crosstermion/Cargo.toml
+++ b/crosstermion/Cargo.toml
@@ -28,8 +28,8 @@ tui-crossterm-backend = ["tui/crossterm"]
 
 
 [dependencies]
-crossterm = { version = "0.25.0", optional = true, default-features = false }
-termion = { version = "1.5.5", optional = true, default-features = false }
+crossterm = { version = "0.26.1", optional = true, default-features = false }
+termion = { version = "2.0.1", optional = true, default-features = false }
 futures-channel = { version = "0.3.5", optional = true, default-features = false, features = ["std", "sink"] }
 futures-core = { version = "0.3.5", optional = true, default-features = false }
 futures-lite = { version = "1.4.0", optional = true }

--- a/crosstermion/src/terminal.rs
+++ b/crosstermion/src/terminal.rs
@@ -81,9 +81,10 @@ mod _impl {
     impl<T: io::Write> AlternateRawScreen<termion::raw::RawTerminal<T>> {
         pub fn try_from(write: T) -> Result<Self, io::Error> {
             use termion::raw::IntoRawMode;
+            use termion::screen::IntoAlternateScreen;
             let write = write.into_raw_mode()?;
             Ok(AlternateRawScreen {
-                inner: termion::screen::AlternateScreen::from(write),
+                inner: write.into_alternate_screen()?,
             })
         }
     }

--- a/tui-react/Cargo.toml
+++ b/tui-react/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tui = { version = "0.19.0", default-features = false }
+tui = { package = "ratatui", version = "0.20.1", default-features = false }
 log = "0.4.6"
 unicode-segmentation = "1.6.0"
 unicode-width = "0.1.7"

--- a/tui-react/README.md
+++ b/tui-react/README.md
@@ -17,11 +17,10 @@ greatly adding to flexibility.
 State that one wants within the component for instance could be the scoll location. Alternatively,
 one can configure windows by altering their public state.
 
-### What's the relation to TUI?
+### What's the relation to TUI / Ratatui?
 
-This project coudln't exist without it, and is happy to provide an alternative set of components
-for use in command-line applications.
-
+This project couldn't exist without TUI, and is happy to provide an alternative set of components
+for use in command-line applications. Ratatui is the continuation of the tui project.
 
 ### Why `tui-react`?
 


### PR DESCRIPTION
However would still be a breaking change for anyone leaving `tui` in
their dependency tree.
