### PR TITLE
feat: replace `ansiterm` with `nu-ansi-term`

### DIFF
--- a/crosstermion/Cargo.toml
+++ b/crosstermion/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
 [features]
 default = []
 
-color = ["ansiterm"]
+color = ["nu-ansi-term"]
 
 input-async = ["futures-channel", "async-channel", "futures-lite", "futures-core" ]
 input-async-crossterm = ["crossterm/event-stream", "input-async"]
@@ -28,9 +28,9 @@ crossterm = { version = "0.27.0", optional = true, default-features = false, fea
 futures-channel = { version = "0.3.5", optional = true, default-features = false, features = ["std", "sink"] }
 futures-core = { version = "0.3.5", optional = true, default-features = false }
 futures-lite = { version = "2.1.0", optional = true }
+nu-ansi-term = { version = "0.50", optional = true, default-features = false }
 tui = { package = "ratatui", version = "0.26.0", optional = true, default-features = false }
 tui-react = { version = "^0.23.2", optional = true, default-features = false, path = "../tui-react" }
-ansiterm = { version = "0.12.2", optional = true, default-features = false }
 async-channel = { version = "2.1.1", optional = true }
 
 [target."cfg(windows)".dependencies]

--- a/crosstermion/src/color.rs
+++ b/crosstermion/src/color.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::ffi::OsStr;
 
-#[cfg(feature = "ansiterm")]
+#[cfg(feature = "nu-ansi-term")]
 mod _impl {
-    use ansiterm::{ANSIGenericString, Style};
+    use nu_ansi_term::{AnsiGenericString, Style};
 
     pub struct Brush {
         may_paint: bool,
@@ -27,20 +27,20 @@ mod _impl {
         pub fn paint<'a, I, S: 'a + ToOwned + ?Sized>(
             &mut self,
             input: I,
-        ) -> ANSIGenericString<'a, S>
+        ) -> AnsiGenericString<'a, S>
         where
             I: Into<std::borrow::Cow<'a, S>>,
             <S as ToOwned>::Owned: std::fmt::Debug,
         {
             match (self.may_paint, self.style.as_ref().take()) {
                 (true, Some(style)) => style.paint(input),
-                (_, Some(_)) | (_, None) => ANSIGenericString::from(input),
+                (_, Some(_)) | (_, None) => AnsiGenericString::from(input),
             }
         }
     }
 }
 
-#[cfg(feature = "ansiterm")]
+#[cfg(feature = "nu-ansi-term")]
 pub use _impl::*;
 
 /// Return true if we should colorize the output, based on [clicolors spec](https://bixense.com/clicolors/) and [no-color spec](https://no-color.org)

--- a/crosstermion/src/input.rs
+++ b/crosstermion/src/input.rs
@@ -47,10 +47,9 @@ pub fn input_channel() -> std::sync::mpsc::Receiver<Event> {
                 Action::Continue => continue,
                 Action::Result(res) => res?,
             };
-            if let Ok(event) = event.try_into() {
-                if key_send.send(event).is_err() {
-                    break;
-                }
+            let Ok(event) = event.try_into();
+            if key_send.send(event).is_err() {
+                break;
             }
         }
         Ok(())

--- a/crosstermion/src/lib.rs
+++ b/crosstermion/src/lib.rs
@@ -11,10 +11,10 @@ pub mod cursor;
 pub mod color;
 
 // Reexports
-#[cfg(feature = "nu-ansi-term")]
-pub use nu_ansi_term;
 #[cfg(feature = "crossterm")]
 pub use crossterm;
+#[cfg(feature = "nu-ansi-term")]
+pub use nu_ansi_term;
 #[cfg(feature = "tui")]
 pub use tui;
 #[cfg(feature = "tui-react")]

--- a/crosstermion/src/lib.rs
+++ b/crosstermion/src/lib.rs
@@ -11,8 +11,8 @@ pub mod cursor;
 pub mod color;
 
 // Reexports
-#[cfg(feature = "ansiterm")]
-pub use ansiterm as ansi_term;
+#[cfg(feature = "nu-ansi-term")]
+pub use nu_ansi_term;
 #[cfg(feature = "crossterm")]
 pub use crossterm;
 #[cfg(feature = "tui")]

--- a/tui-react/src/lib.rs
+++ b/tui-react/src/lib.rs
@@ -6,7 +6,6 @@ mod terminal;
 pub use list::*;
 pub use terminal::*;
 
-use std::iter::repeat;
 use tui::{self, buffer::Buffer, layout::Rect, style::Color, style::Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
@@ -15,7 +14,7 @@ pub fn fill_background_to_right(mut s: String, entire_width: u16) -> String {
     match (s.len(), entire_width as usize) {
         (x, y) if x >= y => s,
         (x, y) => {
-            s.extend(repeat(' ').take(y - x));
+            s.extend(std::iter::repeat_n(' ', y - x));
             s
         }
     }
@@ -52,7 +51,7 @@ pub fn draw_text_with_ellipsis_nowrap(
             if x + 1 == bound.right() {
                 ellipsis_candidate_x = Some(x);
             }
-            cell.set_symbol(g.into());
+            cell.set_symbol(g);
             if let Some(s) = s {
                 cell.set_style(s);
             }
@@ -68,7 +67,7 @@ pub fn draw_text_with_ellipsis_nowrap(
             }
         }
         if let (Some(_), Some(x)) = (graphemes.next(), ellipsis_candidate_x) {
-            buf.get_mut(x, bound.y).set_symbol("…".into());
+            buf.get_mut(x, bound.y).set_symbol("…");
         }
     }
     total_width as u16
@@ -85,7 +84,7 @@ pub fn draw_text_nowrap_fn(
     }
     for (g, x) in t.as_ref().graphemes(true).zip(bound.left()..bound.right()) {
         let cell = buf.get_mut(x, bound.y);
-        cell.set_symbol(g.into());
+        cell.set_symbol(g);
         cell.set_style(s(cell.symbol(), x, bound.y));
     }
 }

--- a/tui-react/src/list.rs
+++ b/tui-react/src/list.rs
@@ -14,7 +14,7 @@ pub struct List {
 impl List {
     fn list_offset_for(&self, entry_in_view: Option<usize>, height: usize) -> usize {
         match entry_in_view {
-            Some(pos) => match height as usize {
+            Some(pos) => match height {
                 h if (self.offset + h).saturating_sub(1) < pos => pos - h + 1,
                 _ if self.offset > pos => pos,
                 _ => self.offset,

--- a/tui-react/src/terminal.rs
+++ b/tui-react/src/terminal.rs
@@ -138,6 +138,7 @@ mod tests {
     use super::*;
     use tui::backend::TestBackend;
 
+    #[expect(dead_code)]
     #[derive(Default, Clone)]
     struct ComplexProps {
         x: usize,
@@ -175,7 +176,7 @@ mod tests {
         term.render(&mut c, 3usize).ok();
         assert_eq!(c.x, 3);
 
-        let mut c = StatelessComponent::default();
+        let mut c = StatelessComponent;
         term.render(&mut c, ComplexProps::default()).ok();
     }
 }


### PR DESCRIPTION
nu-ansi-term is more popular and maintained than ansiterm

According to https://crates.io/crates/ansiterm/reverse_dependencies, crosstermion is the most popular thing using ansiterm.

This replaces 5533fe6db074b0ba132ea01df41bde45182a4933